### PR TITLE
Fix Typo (Normalization to Distribution)

### DIFF
--- a/example/01-Math_Numpy.ipynb
+++ b/example/01-Math_Numpy.ipynb
@@ -2,16 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c0c75642",
    "metadata": {},
    "source": [
-    "## Gaussian Normalization"
+    "## Gaussian Distribution"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "0884fcef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +20,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a58b8402",
    "metadata": {
     "scrolled": true
    },
@@ -49,16 +46,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d19b26d",
    "metadata": {},
    "source": [
-    "## Gaussian Normalization Graph Implementation"
+    "## Gaussian Distribution Graph Implementation"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5c28e404",
    "metadata": {},
    "outputs": [
     {
@@ -87,7 +82,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "425b9724",
    "metadata": {},
    "source": [
     "### Eigen Vector, Eigen Value"
@@ -96,7 +90,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "957d2e2f",
    "metadata": {},
    "outputs": [
     {
@@ -125,7 +118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c088fec1",
    "metadata": {},
    "source": [
     "### Eigen Vector, Eigen Value, PCA"
@@ -134,7 +126,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9b9115df",
    "metadata": {},
    "outputs": [
     {
@@ -162,7 +153,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "594fd944",
    "metadata": {},
    "outputs": [
     {
@@ -188,7 +178,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f66a28f2",
    "metadata": {},
    "source": [
     "### Numeric Differentiation"
@@ -197,7 +186,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4135a244",
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +211,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db065265",
    "metadata": {},
    "source": [
     "### Graph"
@@ -232,7 +219,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "50421da4",
    "metadata": {},
    "outputs": [
     {
@@ -265,7 +251,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c2aed22",
    "metadata": {},
    "source": [
     "### Computational Graph"
@@ -274,7 +259,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "81c2a106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +280,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ab15ca89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +297,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6a97386b",
    "metadata": {},
    "outputs": [
     {
@@ -344,7 +326,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "93f953d7",
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +353,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "affaa628",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -394,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix Typo in 01-Math_Numpy
**Gaussian Normalization** to **Gaussian Distribution**

예제 자료에서 **Gaussian Distribution**이 문맥 상 맞는 표현 같아 요청드립니다!
좋은 수업 해주셔서 늘 감사합니다! 
덕분에 열심히 공부하고 있습니다 :)